### PR TITLE
fix typo

### DIFF
--- a/element/a/index.html
+++ b/element/a/index.html
@@ -177,7 +177,7 @@ elementName: a
                   </code>
                 </h4>
               <div class="value-description">
-                <p>Opens in the parent browsing context, or <code>_self</code> is there is none.</p>
+                <p>Opens in the parent browsing context, or <code>_self</code> if there is none.</p>
 
               </div>
             </header>
@@ -193,7 +193,7 @@ elementName: a
                   </code>
                 </h4>
               <div class="value-description">
-                <p>Opens in the top browsing context, or <code>_self</code> is there is none.</p>
+                <p>Opens in the top browsing context, or <code>_self</code> if there is none.</p>
 
               </div>
             </header>


### PR DESCRIPTION
is -> if

Opens in the parent browsing context, or _self **_is_** there is none.
Opens in the parent browsing context, or _self **_is_** there is none.